### PR TITLE
Add Optional Feature to Hide Tiled Window Titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Based on (but not forked from) [bahamondev/hide-titles](https://github.com/baham
 * Automatically filters out potential breakages (e.g. GTK applications)
 * Configurable blacklist
 * Optional screen edge listener to toggle it off/on in case you need the title bar for a moment
+* Optionally also hide window titles for tiled windows
 
 ![usage demonstration](https://images.pling.com/img/00/00/71/36/84/2018573/video.gif)
 

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -36,10 +36,10 @@ function windowAdded(window) {
 		function statusChanged() {
 			window.noBorder = shouldHideTitle(window);
 		}
+		// always connect all signals even if the related option is disabled
+		// to support config hot reloading if KWin supports that
 		window.maximizedChanged.connect(statusChanged);
-		if (shouldHideTiled) {
-			window.tileChanged.connect(statusChanged);
-		}
+		window.tileChanged.connect(statusChanged);
 	}
 }
 workspace.windowAdded.connect(windowAdded);

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -5,5 +5,8 @@
 		<entry name="blacklist" type="String">
 			<default>yakuake</default>
 		</entry>
+		<entry name="shouldHideTiled" type="Bool">
+			<default>false</default>
+		</entry>
 	</group>
 </kcfg>

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -44,6 +44,20 @@
     <widget class="QLineEdit" name="kcfg_blacklist"/>
    </item>
    <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_optional">
+     <property name="text">
+      <string>Optional Features:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QCheckBox" name="kcfg_shouldHideTiled">
      <property name="text">
       <string>Also &amp;hide title bar for tiled windows</string>

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -1,66 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-	<class>Form</class>
-	<widget class="QWidget" name="Form">
-		<!-- After creating with Qt Designer, geometry was swapped out for minimumSize -->
-		<property name="minimumSize">
-			<size>
-				<height>142</height>
-			</size>
-		</property>
-		<property name="windowTitle">
-			<string>Form</string>
-		</property>
-		<widget class="QLabel" name="label_save_notice">
-			<property name="geometry">
-				<rect>
-					<x>0</x>
-					<y>10</y>
-					<width>541</width>
-					<height>41</height>
-				</rect>
-			</property>
-			<property name="font">
-				<font>
-					<pointsize>11</pointsize>
-					<weight>75</weight>
-					<bold>true</bold>
-				</font>
-			</property>
-			<property name="text">
-				<string>Due to a limitation of Kwin, you must disable and re-enable the script
-for changes to take effect.</string>
-			</property>
-		</widget>
-		<widget class="QLabel" name="label_blacklist">
-			<property name="geometry">
-				<rect>
-					<x>0</x>
-					<y>80</y>
-					<width>301</width>
-					<height>18</height>
-				</rect>
-			</property>
-			<property name="font">
-				<font>
-					<pointsize>11</pointsize>
-				</font>
-			</property>
-			<property name="text">
-				<string>Window Class Blacklist (comma-separated)</string>
-			</property>
-		</widget>
-		<widget class="QLineEdit" name="kcfg_blacklist">
-			<property name="geometry">
-				<rect>
-					<x>0</x>
-					<y>100</y>
-					<width>531</width>
-					<height>32</height>
-				</rect>
-			</property>
-		</widget>
-	</widget>
-	<resources/>
-	<connections/>
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>755</width>
+    <height>142</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>142</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label_save_notice">
+     <property name="font">
+      <font>
+       <pointsize>11</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Due to a limitation of Kwin, you must disable and re-enable the script for changes to take effect.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_blacklist">
+     <property name="text">
+      <string>Window Class Blacklist (comma-separated)</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="kcfg_blacklist"/>
+   </item>
+   <item>
+    <widget class="QRadioButton" name="kcfg_shouldHideTiled">
+     <property name="text">
+      <string>Also &amp;hide title bar for tiled windows</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
 </ui>

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -44,7 +44,7 @@
     <widget class="QLineEdit" name="kcfg_blacklist"/>
    </item>
    <item>
-    <widget class="QRadioButton" name="kcfg_shouldHideTiled">
+    <widget class="QCheckBox" name="kcfg_shouldHideTiled">
      <property name="text">
       <string>Also &amp;hide title bar for tiled windows</string>
      </property>


### PR DESCRIPTION
Hi! First of all thank you for your script, it works great!

I tried adding a small feature to this script: an option (defaul off) to also hide window titles for tiled windows (a feature first introduced in KDE Plasma 5.27). Previously window decoration is still displayed when a window is tiled, and wastes screen space in the same way as maximized windows.

Before:
![Screenshot_20241217_215016](https://github.com/user-attachments/assets/9f7cf13e-e678-4aed-b816-4182f900a489)

After:
![Screenshot_20241217_215156](https://github.com/user-attachments/assets/27e3535d-ac22-4c8e-bb59-49dc72f6b7fc)

P.S. I'm new to KWin scripting so I kind of took this as a small practice. If I've done anything wrong here please tell me. Thanks!