### PR TITLE
Auto hide title bar again when moving cursor away

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -54,6 +54,13 @@ workspace.windowRemoved.connect((window) => {
 	}
 });
 
+function cursorPosChanged() {
+	if (shouldHideTitle(workspace.activeWindow) && workspace.cursorPos.y > (workspaceHeight * 0.1)) {
+		workspace.activeWindow.noBorder = true;
+	}
+}
+workspace.cursorPosChanged.connect(cursorPosChanged);
+
 var lastScreenEdge = 0;
 function screenEdgeActivated() {
 	if (Date.now() - lastScreenEdge < 200) {
@@ -63,7 +70,7 @@ function screenEdgeActivated() {
 	for (window of workspace.windowList()) {
 		if (window.active) {
 			if (isManaged(window) && shouldHideTitle(window)) {
-				window.noBorder = !window.noBorder;
+				window.noBorder = false;
 				lastScreenEdge = Date.now();
 			}
 			return;

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -55,7 +55,12 @@ workspace.windowRemoved.connect((window) => {
 });
 
 function cursorPosChanged() {
-	if (isManaged(workspace.activeWindow) && shouldHideTitle(workspace.activeWindow) && workspace.cursorPos.y > (workspace.workspaceHeight * 0.1)) {
+	if (
+		registeredBorders.length > 0
+		&& isManaged(workspace.activeWindow)
+		&& shouldHideTitle(workspace.activeWindow)
+		&& workspace.cursorPos.y > (workspace.workspaceHeight * 0.1)
+	) {
 		workspace.activeWindow.noBorder = true;
 	}
 }

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -1,5 +1,6 @@
 // utils
 var shouldHideTiled = false;
+var autoHideAt = 200;
 
 function shouldHideTitle(window) {
 	if (monitorBlacklist.includes(window.output.name)) {
@@ -55,6 +56,7 @@ workspace.windowRemoved.connect((window) => {
 });
 
 function cursorPosChanged() {
+	if (autoHideAt == 0) return;
 	var activeScreen = workspace.activeScreen;
 	if (activeScreen == null) return;
 	var screenHeight = activeScreen.geometry.height;
@@ -63,7 +65,7 @@ function cursorPosChanged() {
 		registeredBorders.length > 0
 		&& isManaged(workspace.activeWindow)
 		&& shouldHideTitle(workspace.activeWindow)
-		&& localCursorPos.y > 150
+		&& localCursorPos.y > autoHideAt
 	) {
 		workspace.activeWindow.noBorder = true;
 	}
@@ -79,7 +81,7 @@ function screenEdgeActivated() {
 	for (window of workspace.windowList()) {
 		if (window.active) {
 			if (isManaged(window) && shouldHideTitle(window)) {
-				window.noBorder = false;
+				window.noBorder = autoHideAt == 0 && !window.noBorder;
 				lastScreenEdge = Date.now();
 			}
 			return;
@@ -110,6 +112,7 @@ function init() {
 	windowBlacklist = readConfig("windowBlacklist", "yakuake").split(",").filter((name) => name.length != 0);
 	monitorBlacklist = readConfig("monitorBlacklist", "").split(",").filter((name) => name.length != 0);
 	shouldHideTiled = readConfig("shouldHideTiled", false);
+	autoHideAt = readConfig("autoHideAt", 200);
 	initScreenEdges();
 }
 options.configChanged.connect(init);

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -55,7 +55,7 @@ workspace.windowRemoved.connect((window) => {
 });
 
 function cursorPosChanged() {
-	if (shouldHideTitle(workspace.activeWindow) && workspace.cursorPos.y > (workspaceHeight * 0.1)) {
+	if (isManaged(workspace.activeWindow) && shouldHideTitle(workspace.activeWindow) && workspace.cursorPos.y > (workspace.workspaceHeight * 0.1)) {
 		workspace.activeWindow.noBorder = true;
 	}
 }

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -55,11 +55,15 @@ workspace.windowRemoved.connect((window) => {
 });
 
 function cursorPosChanged() {
+	var activeScreen = workspace.activeScreen;
+	if (activeScreen == null) return;
+	var screenHeight = activeScreen.geometry.height;
+	var localCursorPos = activeScreen.mapFromGlobal(workspace.cursorPos);
 	if (
 		registeredBorders.length > 0
 		&& isManaged(workspace.activeWindow)
 		&& shouldHideTitle(workspace.activeWindow)
-		&& workspace.cursorPos.y > (workspace.workspaceHeight * 0.1)
+		&& localCursorPos.y > 150
 	) {
 		workspace.activeWindow.noBorder = true;
 	}

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -11,5 +11,8 @@
 		<entry name="monitorBlacklist" type="String">
 			<default></default>
 		</entry>
+		<entry name="autoHideAt" type="Int">
+			<default>200</default>
+		</entry>
 	</group>
 </kcfg>

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -60,6 +60,32 @@
     <widget class="KSeparator" name="kseparator_4"/>
    </item>
    <item>
+    <widget class="QLabel" name="label_autoHideAt">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Auto Hide Offset&lt;/span&gt;&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;automatially re-hides the titlebar at this distance (0 disables auto hide)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QSpinBox" name="kcfg_autoHideAt">
+     <property name="suffix">
+      <string> px</string>
+     </property>
+     <property name="maximum">
+      <number>10000</number>
+     </property>
+     <property name="singleStep">
+      <number>100</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="KSeparator" name="kseparator_7"/>
+   </item>
+   <item>
+    <widget class="KSeparator" name="kseparator_8"/>
+   </item>
+   <item>
     <widget class="QLabel" name="label_windowBlacklist">
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Ignore Windows&lt;/span&gt;&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;comma-separated list of window classes&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>


### PR DESCRIPTION
I've changed the behavior to re-hide the title bar when moving the cursor away (downwards) from it, instead of having to hit the edge again to hide the bar. It feels a lot nicer to me, especially when accidentally triggering the edge.

What I'm not sure about (and thus made this a "draft"):
- Should this replace the current behavior (as it does right now), or should I make it an option?
- Should we care about _crazy_ people who put their title bar or an edge trigger on the left / right / bottom instead of the top? Can you even have title bars on those edges?

[Screencast_20260304_162223.webm](https://github.com/user-attachments/assets/a9226562-53d4-49bf-afe1-302179e5545f)
